### PR TITLE
add WHO and CDC resource links

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,9 +223,45 @@ These images were inspired by images posted by <a href="https://twitter.com/Emma
 </p>
 </div>
 </div>
+ 
+<div id="outline-container-org397e2f1" class="outline-2">
+<h2 id="org397e2f1"><span class="section-number-2">5</span> Resources</h2>
+<div class="outline-text-2" id="text-3">
+<p>
+Official Resources for COVID-19
+</p>
+
+<table>
+
+
+<colgroup>
+<col  class="org-left">
+
+<col  class="org-left">
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Organization</th>
+<th scope="col" class="org-left">Link</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left">WHO</td>
+<td class="org-left"><a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019">https://www.who.int/emergencies/diseases/novel-coronavirus-2019</a></td>
+</tr>
+
+<tr>
+<td class="org-left">CDC</td>
+<td class="org-left"><a href="https://www.cdc.gov/coronavirus/2019-nCoV/index.html">https://www.cdc.gov/coronavirus/2019-nCoV/index.html</a></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 
 <div id="outline-container-orgb367a7f" class="outline-2">
-<h2 id="orgb367a7f"><span class="section-number-2">5</span> Colophon</h2>
+<h2 id="orgb367a7f"><span class="section-number-2">6</span> Colophon</h2>
 <div class="outline-text-2" id="text-5">
 <p>
 This project was made with:


### PR DESCRIPTION
Let's do our part to keep the official resource links front-and-center. They can be swapped out easily the next time this page is revived for something else (which, let's be honest, we hope we never have to).